### PR TITLE
Fix plugin audio port scan, add dropseed-example and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,67 @@
+name: Test
+
+on: [push, pull_request]
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable, beta, nightly]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install libgl-dev libxcursor-dev libxcb-dri2-0-dev libxcb-icccm4-dev libx11-xcb-dev libasound2-dev
+    - if: matrix.os == 'macos-latest'
+      run: brew install mesa
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.toolchain }}
+        override: true
+    - name: Build
+      run: cargo build --all --verbose
+    - name: Run tests
+      run: cargo test --all --verbose
+
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - run: sudo apt-get install libgl-dev libxcursor-dev libxcb-dri2-0-dev libxcb-icccm4-dev libx11-xcb-dev libasound2-dev
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+    - name: Format
+      run: cargo fmt --all -- --check
+    - uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all --all-features # -- -D warnings TODO: enable this when all warnings are fixed
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get install libgl-dev libxcursor-dev libxcb-dri2-0-dev libxcb-icccm4-dev libx11-xcb-dev libasound2-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri
+      - uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: setup
+      - uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test --all --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace]
+members = ["examples/test-host"]
+
 [features]
 default = ["clap-host", "cpal-backend"]
-clap-host = ["libloading", "globwalk", "dirs"]
+clap-host = ["globwalk", "dirs"]
 cpal-backend = ["cpal"]
 cpal-asio = ["cpal/asio"]
 
@@ -37,10 +40,12 @@ fnv = "1.0"
 log = "0.4"
 thread-priority = "0.8"
 cpal = { version = "0.13", optional = true }
-libloading = { version = "0.7", optional = true }
 globwalk = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 # TODO: Add two features: one to use the symphonia dependency, and one to use the non-open source formats with symphonia.
 symphonia = { version = "0.5", features = ["flac", "mkv", "ogg", "pcm", "vorbis", "wav", "mp3", "aac", "alac"]}
 twox-hash = "1.6"
 bincode = "1.3.3"
+
+[profile.release]
+lto = true

--- a/examples/test-host/Cargo.toml
+++ b/examples/test-host/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "test-host"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+dropseed = { path = "../../" }
+#noise-generator-dropseed = { git = "https://github.com/MeadowlarkDAW/meadowlark-plugins", package = "noise-generator-dropseed", branch = "main" }
+#noise-generator-dropseed = { path = "../meadowlark-plugins/noise-generator/noise-generator-dropseed" }
+meadowlark-core-types = { git = "https://github.com/MeadowlarkDAW/meadowlark-core-types.git", branch = "main" }
+eframe = "0.18"
+cpal = "0.13"
+crossbeam = "0.8"
+ringbuf = "0.2"
+fnv = "1.0"
+fast_log = "1.5.16"
+log = "0.4"
+basedrop = "0.1"

--- a/examples/test-host/README.md
+++ b/examples/test-host/README.md
@@ -1,0 +1,6 @@
+# dropseed-example
+A basic example of how to use the [`dropseed`] DAW audio engine with a GUI
+
+(WIP)
+
+[`dropseed`]: https://github.com/MeadowlarkDAW/dropseed

--- a/examples/test-host/src/effect_rack_page.rs
+++ b/examples/test-host/src/effect_rack_page.rs
@@ -1,0 +1,365 @@
+use dropseed::{
+    plugin::PluginSaveState, DSEngineHandle, EdgeReq, EdgeReqPortID, ModifyGraphRequest, ParamID,
+    ParamInfoFlags, ParamModifiedInfo, PluginHandle, PluginIDReq, PluginInstanceID, PortType,
+};
+use eframe::egui;
+use fnv::FnvHashMap;
+
+use super::DSExampleGUI;
+
+pub struct ParamState {
+    id: ParamID,
+
+    display_name: String,
+
+    value: f64,
+
+    min_value: f64,
+    max_value: f64,
+
+    is_stepped: bool,
+    is_read_only: bool,
+    is_hidden: bool,
+
+    is_gesturing: bool,
+}
+
+pub struct ParamsState {
+    params: FnvHashMap<ParamID, ParamState>,
+}
+
+impl ParamsState {
+    pub fn new(handle: &PluginHandle, param_values: FnvHashMap<ParamID, f64>) -> Self {
+        let mut new_self = Self { params: FnvHashMap::default() };
+
+        new_self.update_handle(handle, param_values);
+
+        new_self
+    }
+
+    pub fn update_handle(
+        &mut self,
+        new_handle: &PluginHandle,
+        param_values: FnvHashMap<ParamID, f64>,
+    ) {
+        self.params.clear();
+
+        for info in new_handle.params.params.values() {
+            let _ = self.params.insert(
+                info.stable_id,
+                ParamState {
+                    id: info.stable_id,
+                    display_name: info.display_name.clone(),
+                    value: *param_values.get(&info.stable_id).unwrap(),
+                    min_value: info.min_value,
+                    max_value: info.max_value,
+                    is_stepped: info.flags.contains(ParamInfoFlags::IS_STEPPED),
+                    is_read_only: info.flags.contains(ParamInfoFlags::IS_READONLY),
+                    is_hidden: info.flags.contains(ParamInfoFlags::IS_HIDDEN),
+                    is_gesturing: false,
+                },
+            );
+        }
+    }
+
+    pub fn parameters_modified(&mut self, modified_params: &[ParamModifiedInfo]) {
+        for m_p in modified_params.iter() {
+            let param = self.params.get_mut(&m_p.param_id).unwrap();
+
+            if let Some(new_value) = m_p.new_value {
+                param.value = new_value;
+            }
+
+            param.is_gesturing = m_p.is_gesturing;
+        }
+    }
+}
+
+pub struct EffectRackPluginActiveState {
+    pub handle: PluginHandle,
+    pub params_state: ParamsState,
+}
+
+impl EffectRackPluginActiveState {
+    pub fn new(handle: PluginHandle, param_values: FnvHashMap<ParamID, f64>) -> Self {
+        let params_state = ParamsState::new(&handle, param_values);
+
+        Self { handle, params_state }
+    }
+}
+
+pub struct EffectRackPluginState {
+    pub plugin_name: String,
+    pub plugin_id: PluginInstanceID,
+
+    pub active_state: Option<EffectRackPluginActiveState>,
+}
+
+impl EffectRackPluginState {
+    pub fn set_inactive(&mut self) {
+        self.active_state = None;
+    }
+
+    pub fn update_handle(
+        &mut self,
+        new_handle: PluginHandle,
+        param_values: FnvHashMap<ParamID, f64>,
+    ) {
+        self.active_state = Some(EffectRackPluginActiveState::new(new_handle, param_values));
+    }
+}
+
+pub struct EffectRackState {
+    pub selected_to_add_plugin_i: Option<usize>,
+
+    pub plugins: Vec<EffectRackPluginState>,
+}
+
+impl EffectRackState {
+    pub fn new() -> Self {
+        Self { selected_to_add_plugin_i: None, plugins: Vec::new() }
+    }
+
+    pub fn plugin(&self, id: &PluginInstanceID) -> Option<&EffectRackPluginState> {
+        let mut found = None;
+        for p in self.plugins.iter() {
+            if &p.plugin_id == id {
+                found = Some(p);
+                break;
+            }
+        }
+        found
+    }
+
+    pub fn plugin_mut(&mut self, id: &PluginInstanceID) -> Option<&mut EffectRackPluginState> {
+        let mut found = None;
+        for p in self.plugins.iter_mut() {
+            if &p.plugin_id == id {
+                found = Some(p);
+                break;
+            }
+        }
+        found
+    }
+
+    pub fn remove_plugin(&mut self, id: &PluginInstanceID) {
+        let mut found = None;
+        for (i, p) in self.plugins.iter().enumerate() {
+            if &p.plugin_id == id {
+                found = Some(i);
+                break;
+            }
+        }
+        if let Some(i) = found {
+            let _ = self.plugins.remove(i);
+        }
+    }
+}
+
+pub(crate) fn show(app: &mut DSExampleGUI, ui: &mut egui::Ui) {
+    if let Some(engine_state) = &mut app.engine_state {
+        ui.horizontal(|ui| {
+            let selected_text =
+                if let Some(plugin_i) = engine_state.effect_rack_state.selected_to_add_plugin_i {
+                    &app.plugin_list[plugin_i].1
+                } else {
+                    "<select a plugin>"
+                };
+
+            egui::ComboBox::from_id_source("plugin_to_add").selected_text(selected_text).show_ui(
+                ui,
+                |ui| {
+                    ui.selectable_value(
+                        &mut engine_state.effect_rack_state.selected_to_add_plugin_i,
+                        None,
+                        "<select a plugin>",
+                    );
+
+                    for (plugin_i, plugin) in app.plugin_list.iter().enumerate() {
+                        ui.selectable_value(
+                            &mut engine_state.effect_rack_state.selected_to_add_plugin_i,
+                            Some(plugin_i),
+                            &plugin.1,
+                        );
+                    }
+                },
+            );
+
+            if ui.button("Add Plugin").clicked() {
+                if let Some(plugin_i) = engine_state.effect_rack_state.selected_to_add_plugin_i {
+                    let key = app.plugin_list[plugin_i].0.key.clone();
+
+                    let request = ModifyGraphRequest {
+                        add_plugin_instances: vec![PluginSaveState::new_with_default_preset(key)],
+                        remove_plugin_instances: vec![],
+                        connect_new_edges: vec![
+                            EdgeReq {
+                                edge_type: PortType::Audio,
+                                src_plugin_id: PluginIDReq::Existing(
+                                    engine_state.graph_in_node_id.clone(),
+                                ),
+                                dst_plugin_id: PluginIDReq::Added(0),
+                                src_port_id: EdgeReqPortID::Main,
+                                src_port_channel: 0,
+                                dst_port_id: EdgeReqPortID::Main,
+                                dst_port_channel: 0,
+                                log_error_on_fail: true,
+                            },
+                            EdgeReq {
+                                edge_type: PortType::Audio,
+                                src_plugin_id: PluginIDReq::Existing(
+                                    engine_state.graph_in_node_id.clone(),
+                                ),
+                                dst_plugin_id: PluginIDReq::Added(0),
+                                src_port_id: EdgeReqPortID::Main,
+                                src_port_channel: 1,
+                                dst_port_id: EdgeReqPortID::Main,
+                                dst_port_channel: 1,
+                                log_error_on_fail: true,
+                            },
+                            EdgeReq {
+                                edge_type: PortType::Audio,
+                                src_plugin_id: PluginIDReq::Added(0),
+                                dst_plugin_id: PluginIDReq::Existing(
+                                    engine_state.graph_out_node_id.clone(),
+                                ),
+                                src_port_id: EdgeReqPortID::Main,
+                                src_port_channel: 0,
+                                dst_port_id: EdgeReqPortID::Main,
+                                dst_port_channel: 0,
+                                log_error_on_fail: true,
+                            },
+                            EdgeReq {
+                                edge_type: PortType::Audio,
+                                src_plugin_id: PluginIDReq::Added(0),
+                                dst_plugin_id: PluginIDReq::Existing(
+                                    engine_state.graph_out_node_id.clone(),
+                                ),
+                                src_port_id: EdgeReqPortID::Main,
+                                src_port_channel: 1,
+                                dst_port_id: EdgeReqPortID::Main,
+                                dst_port_channel: 1,
+                                log_error_on_fail: true,
+                            },
+                        ],
+                        disconnect_edges: vec![],
+                    };
+
+                    app.engine_handle.send(request.into());
+                }
+            }
+        });
+
+        for (plugin_i, plugin) in engine_state.effect_rack_state.plugins.iter_mut().enumerate() {
+            show_effect_rack_plugin(ui, plugin_i, plugin, &mut app.engine_handle);
+        }
+    } else {
+        ui.label("Audio engine is deactivated");
+    }
+}
+
+pub(crate) fn show_effect_rack_plugin(
+    ui: &mut egui::Ui,
+    plugin_i: usize,
+    plugin: &mut EffectRackPluginState,
+    engine_handle: &mut DSEngineHandle,
+) {
+    egui::Frame::default()
+        .inner_margin(egui::style::Margin::same(10.0))
+        .outer_margin(egui::style::Margin::same(5.0))
+        .fill(egui::Color32::from_gray(15))
+        .stroke(egui::Stroke::new(1.0, egui::Color32::from_gray(100)))
+        .show(ui, |ui| {
+            egui::ScrollArea::vertical().id_source(&format!("plugin{}hscroll", plugin_i)).show(
+                ui,
+                |ui| {
+                    if ui.small_button("x").clicked() {
+                        let request = ModifyGraphRequest {
+                            add_plugin_instances: vec![],
+                            remove_plugin_instances: vec![plugin.plugin_id.clone()],
+                            connect_new_edges: vec![],
+                            disconnect_edges: vec![],
+                        };
+
+                        engine_handle.send(request.into());
+                    }
+
+                    // TODO: Let the user activate/deactive the plugin in this GUI.
+
+                    if plugin.active_state.is_some() {
+                        ui.colored_label(egui::Color32::GREEN, "activated");
+                    } else {
+                        ui.colored_label(egui::Color32::RED, "deactivated");
+                    }
+
+                    ui.label(&plugin.plugin_name);
+                    ui.label(&format!("id: {:?}", plugin.plugin_id));
+
+                    ui.separator();
+
+                    if let Some(active_state) = &mut plugin.active_state {
+                        // TODO: plugin ports
+
+                        let mut values_to_set: Vec<(ParamID, f64)> = Vec::new();
+
+                        for param in active_state.params_state.params.values_mut() {
+                            if param.is_hidden {
+                                continue;
+                            }
+
+                            if param.is_read_only {
+                                ui.horizontal(|ui| {
+                                    ui.label(&format!(
+                                        "{}: {:.8}",
+                                        &param.display_name, param.value
+                                    ));
+                                });
+
+                                continue;
+                            }
+
+                            ui.horizontal(|ui| {
+                                if param.is_stepped {
+                                    let mut value: i64 = param.value.round() as i64;
+                                    let min_value: i64 = param.min_value.round() as i64;
+                                    let max_value: i64 = param.max_value.round() as i64;
+
+                                    if ui
+                                        .add(
+                                            egui::Slider::new(&mut value, min_value..=max_value)
+                                                .text(&param.display_name),
+                                        )
+                                        .changed()
+                                    {
+                                        values_to_set.push((param.id, value as f64));
+                                        param.value = value as f64;
+                                    }
+                                } else {
+                                    if ui
+                                        .add(
+                                            egui::Slider::new(
+                                                &mut param.value,
+                                                param.min_value..=param.max_value,
+                                            )
+                                            .text(&param.display_name),
+                                        )
+                                        .changed()
+                                    {
+                                        values_to_set.push((param.id, param.value))
+                                    }
+                                }
+
+                                if param.is_gesturing {
+                                    ui.colored_label(egui::Color32::GREEN, "Gesturing");
+                                }
+                            });
+                        }
+
+                        for (param_id, value) in values_to_set.drain(..) {
+                            active_state.handle.params.set_value(param_id, value);
+                        }
+                    }
+                },
+            );
+        });
+}

--- a/examples/test-host/src/main.rs
+++ b/examples/test-host/src/main.rs
@@ -1,0 +1,436 @@
+use cpal::traits::{DeviceTrait, HostTrait};
+use cpal::Stream;
+use crossbeam::channel::Receiver;
+use dropseed::{
+    ActivateEngineSettings, DSEngineAudioThread, DSEngineEvent, DSEngineHandle, DSEngineRequest,
+    EdgeReq, EngineDeactivatedInfo, HostInfo, ModifyGraphRequest, PluginActivationStatus,
+    PluginEvent, PluginIDReq, PluginInstanceID, PluginScannerEvent, PortType, ScannedPlugin,
+};
+use eframe::egui;
+use meadowlark_core_types::SampleRate;
+//use noise_generator_dropseed::NoiseGenPluginFactory;
+
+mod effect_rack_page;
+mod scanned_plugins_page;
+
+use effect_rack_page::{EffectRackPluginActiveState, EffectRackPluginState, EffectRackState};
+
+const MIN_BLOCK_SIZE: u32 = 1;
+const MAX_BLOCK_SIZE: u32 = 512;
+const GRAPH_IN_CHANNELS: u16 = 2;
+const GRAPH_OUT_CHANNELS: u16 = 2;
+
+fn main() {
+    // Prefer to use a logging crate that is wait-free for threads printing
+    // out to the log.
+    fast_log::init(fast_log::Config::new().console().level(log::LevelFilter::Trace)).unwrap();
+
+    let (to_audio_thread_tx, mut from_gui_rx) =
+        ringbuf::RingBuffer::<UIToAudioThreadMsg>::new(10).split();
+
+    // ---  Initialize cpal stream  -----------------------------------------------
+
+    let cpal_host = cpal::default_host();
+
+    let device = cpal_host.default_output_device().expect("no output device available");
+
+    let config = device.default_output_config().expect("no default output config available");
+
+    let num_out_channels = usize::from(config.channels());
+    let sample_rate: SampleRate = config.sample_rate().0.into();
+
+    let mut audio_thread: Option<DSEngineAudioThread> = None;
+
+    let cpal_stream = device
+        .build_output_stream(
+            &config.into(),
+            move |audio_buffer: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                while let Some(msg) = from_gui_rx.pop() {
+                    match msg {
+                        UIToAudioThreadMsg::NewEngineAudioThread(new_audio_thread) => {
+                            audio_thread = Some(new_audio_thread);
+                        }
+                        UIToAudioThreadMsg::DropEngineAudioThread => {
+                            audio_thread = None;
+                        }
+                    }
+                }
+
+                if let Some(audio_thread) = &mut audio_thread {
+                    audio_thread
+                        .process_cpal_interleaved_output_only(num_out_channels, audio_buffer);
+                }
+            },
+            |e| {
+                panic!("{}", e);
+            },
+        )
+        .unwrap();
+
+    // ---  Initialize Dropseed Engine  -------------------------------------------
+
+    let (mut engine_handle, engine_rx) = DSEngineHandle::new(
+        HostInfo::new(String::from("Dropseed Example"), String::from("0.1.0"), None, None),
+        //vec![Box::new(NoiseGenPluginFactory {})],
+        vec![],
+    );
+
+    dbg!(&engine_handle.internal_plugins_res);
+
+    engine_handle.send(DSEngineRequest::ActivateEngine(Box::new(ActivateEngineSettings {
+        sample_rate,
+        min_frames: MIN_BLOCK_SIZE,
+        max_frames: MAX_BLOCK_SIZE,
+        num_audio_in_channels: GRAPH_IN_CHANNELS,
+        num_audio_out_channels: GRAPH_OUT_CHANNELS,
+        ..Default::default()
+    })));
+
+    engine_handle.send(DSEngineRequest::RescanPluginDirectories);
+
+    // ---  Run the UI  -----------------------------------------------------------
+
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "Dropseed Example",
+        options,
+        Box::new(move |cc| {
+            cc.egui_ctx.set_visuals(egui::Visuals::dark());
+
+            Box::new(DSExampleGUI::new(
+                engine_handle,
+                engine_rx,
+                cpal_stream,
+                sample_rate,
+                to_audio_thread_tx,
+            ))
+        }),
+    );
+}
+
+#[derive(Debug)]
+enum UIToAudioThreadMsg {
+    NewEngineAudioThread(DSEngineAudioThread),
+    DropEngineAudioThread,
+}
+
+pub struct EngineState {
+    pub graph_in_node_id: PluginInstanceID,
+    pub graph_out_node_id: PluginInstanceID,
+
+    pub effect_rack_state: EffectRackState,
+}
+
+struct DSExampleGUI {
+    engine_handle: DSEngineHandle,
+    engine_rx: Receiver<DSEngineEvent>,
+
+    to_audio_thread_tx: ringbuf::Producer<UIToAudioThreadMsg>,
+    _cpal_stream: Option<Stream>,
+
+    sample_rate: SampleRate,
+
+    plugin_list: Vec<(ScannedPlugin, String)>,
+
+    failed_plugins_text: Vec<(String, String)>,
+
+    engine_state: Option<EngineState>,
+
+    current_tab: Tab,
+}
+
+impl DSExampleGUI {
+    fn new(
+        engine_handle: DSEngineHandle,
+        engine_rx: Receiver<DSEngineEvent>,
+        cpal_stream: Stream,
+        sample_rate: SampleRate,
+        to_audio_thread_tx: ringbuf::Producer<UIToAudioThreadMsg>,
+    ) -> Self {
+        Self {
+            engine_handle,
+            engine_rx,
+            to_audio_thread_tx,
+            _cpal_stream: Some(cpal_stream),
+            sample_rate,
+            plugin_list: Vec::new(),
+            failed_plugins_text: Vec::new(),
+            engine_state: None,
+            current_tab: Tab::EffectRack,
+        }
+    }
+
+    fn poll_updates(&mut self) {
+        for msg in self.engine_rx.try_iter() {
+            //dbg!(&msg);
+
+            match msg {
+                // Sent whenever the engine is deactivated.
+                //
+                // The DSEngineAudioThread sent in a previous EngineActivated event is now
+                // invalidated. Please drop it and wait for a new EngineActivated event to
+                // replace it.
+                //
+                // To keep using the audio graph, you must reactivate the engine with
+                // `DSEngineRequest::ActivateEngine`, and then restore the audio graph
+                // from an existing save state if you wish using
+                // `DSEngineRequest::RestoreFromSaveState`.
+                DSEngineEvent::EngineDeactivated(res) => {
+                    self.to_audio_thread_tx
+                        .push(UIToAudioThreadMsg::DropEngineAudioThread)
+                        .unwrap();
+
+                    match res {
+                        // The engine was deactivated gracefully after recieving a
+                        // `DSEngineRequest::DeactivateEngine` request.
+                        EngineDeactivatedInfo::DeactivatedGracefully { recovered_save_state } => {
+                            println!("Engine deactivated gracefully");
+                        }
+                        // The engine has crashed.
+                        EngineDeactivatedInfo::EngineCrashed {
+                            error_msg,
+                            recovered_save_state,
+                        } => {
+                            println!("Engine crashed: {}", error_msg);
+                        }
+                    }
+
+                    self.engine_state = None;
+                }
+
+                // This message is sent whenever the engine successfully activates.
+                DSEngineEvent::EngineActivated(info) => {
+                    self.engine_state = Some(EngineState {
+                        graph_in_node_id: info.graph_in_node_id,
+                        graph_out_node_id: info.graph_out_node_id,
+                        effect_rack_state: EffectRackState::new(),
+                    });
+
+                    self.to_audio_thread_tx
+                        .push(UIToAudioThreadMsg::NewEngineAudioThread(info.audio_thread))
+                        .unwrap();
+                }
+
+                // When this message is received, it means that the audio graph is starting
+                // the process of restoring from a save state.
+                //
+                // Reset your UI as if you are loading up a project for the first time, and
+                // wait for the `AudioGraphModified` event to repopulate the UI.
+                //
+                // If the audio graph is in an invalid state as a result of restoring from
+                // the save state, then the `EngineDeactivated` event will be sent instead.
+                DSEngineEvent::AudioGraphCleared => {
+                    if let Some(engine_state) = &mut self.engine_state {
+                        engine_state.effect_rack_state.plugins.clear();
+                    }
+                }
+
+                // This message is sent whenever the audio graph has been modified.
+                //
+                // Be sure to update your UI from this new state.
+                DSEngineEvent::AudioGraphModified(mut res) => {
+                    if let Some(engine_state) = &mut self.engine_state {
+                        for plugin_id in res.removed_plugins.drain(..) {
+                            engine_state.effect_rack_state.remove_plugin(&plugin_id);
+                        }
+
+                        for new_plugin_res in res.new_plugins.drain(..) {
+                            let mut found = None;
+                            for (p, _) in self.plugin_list.iter() {
+                                if p.rdn() == new_plugin_res.plugin_id.rdn() {
+                                    found = Some(p.description.name.clone());
+                                    break;
+                                }
+                            }
+                            let plugin_name = found.unwrap();
+
+                            let active_state = match new_plugin_res.status {
+                                PluginActivationStatus::Activated {
+                                    new_handle,
+                                    new_param_values,
+                                } => Some(EffectRackPluginActiveState::new(
+                                    new_handle,
+                                    new_param_values,
+                                )),
+                                PluginActivationStatus::Inactive => None,
+                                PluginActivationStatus::LoadError(e) => {
+                                    println!("Plugin failed to load: {}", e);
+                                    None
+                                }
+                                PluginActivationStatus::ActivationError(e) => {
+                                    println!("Plugin failed to activate: {}", e);
+                                    None
+                                }
+                            };
+
+                            let effect_rack_plugin = EffectRackPluginState {
+                                plugin_name,
+                                plugin_id: new_plugin_res.plugin_id,
+                                active_state,
+                            };
+
+                            engine_state.effect_rack_state.plugins.push(effect_rack_plugin);
+                        }
+
+                        for (plugin_id, plugin_edges) in res.updated_plugin_edges.drain(..) {
+                            let effect_rack_plugin =
+                                engine_state.effect_rack_state.plugin_mut(&plugin_id).unwrap();
+
+                            if let Some(active_state) = &mut effect_rack_plugin.active_state {
+                                // TODO
+                            }
+                        }
+                    }
+                }
+
+                DSEngineEvent::Plugin(event) => match event {
+                    // Sent whenever a plugin becomes activated after being deactivated or
+                    // when the plugin restarts.
+                    //
+                    // Make sure your UI updates the port configuration on this plugin.
+                    PluginEvent::Activated { plugin_id, new_handle, new_param_values } => {
+                        if let Some(engine_state) = &mut self.engine_state {
+                            let effect_rack_plugin =
+                                engine_state.effect_rack_state.plugin_mut(&plugin_id).unwrap();
+
+                            effect_rack_plugin.update_handle(new_handle, new_param_values);
+                        }
+                    }
+
+                    // Sent whenever a plugin becomes deactivated. When a plugin is deactivated
+                    // you cannot access any of its methods until it is reactivated.
+                    PluginEvent::Deactivated {
+                        plugin_id,
+                        // If this is `Ok(())`, then it means the plugin was gracefully
+                        // deactivated from user request.
+                        //
+                        // If this is `Err(e)`, then it means the plugin became deactivated
+                        // because it failed to restart.
+                        status,
+                    } => {
+                        if let Some(engine_state) = &mut self.engine_state {
+                            let effect_rack_plugin =
+                                engine_state.effect_rack_state.plugin_mut(&plugin_id).unwrap();
+
+                            effect_rack_plugin.set_inactive();
+
+                            if let Err(e) = status {
+                                println!("Plugin failed to activate: {}", e);
+                            }
+                        }
+                    }
+
+                    PluginEvent::ParamsModified { plugin_id, modified_params } => {
+                        if let Some(engine_state) = &mut self.engine_state {
+                            let effect_rack_plugin =
+                                engine_state.effect_rack_state.plugin_mut(&plugin_id).unwrap();
+
+                            if let Some(active_state) = &mut effect_rack_plugin.active_state {
+                                active_state.params_state.parameters_modified(&modified_params);
+                            }
+                        }
+                    }
+
+                    unkown_event => {
+                        dbg!(unkown_event);
+                    }
+                },
+
+                DSEngineEvent::PluginScanner(event) => match event {
+                    // A new CLAP plugin scan path was added.
+                    PluginScannerEvent::ClapScanPathAdded(path) => {
+                        println!("Added clap scan path: {:?}", path);
+                    }
+                    // A CLAP plugin scan path was removed.
+                    PluginScannerEvent::ClapScanPathRemoved(path) => {
+                        println!("Removed clap scan path: {:?}", path);
+                    }
+                    // A request to rescan all plugin directories has finished. Update
+                    // the list of available plugins in your UI.
+                    PluginScannerEvent::RescanFinished(mut info) => {
+                        self.plugin_list = info
+                            .scanned_plugins
+                            .iter()
+                            .map(|plugin| {
+                                let display_choice =
+                                    format!("{} ({})", &plugin.description.name, &plugin.format);
+
+                                (plugin.clone(), display_choice)
+                            })
+                            .collect();
+
+                        self.failed_plugins_text = info
+                            .failed_plugins
+                            .drain(..)
+                            .map(|(path, error)| {
+                                (format!("{}", path.to_string_lossy()), format!("{}", error))
+                            })
+                            .collect();
+                    }
+                    unkown_event => {
+                        dbg!(unkown_event);
+                    }
+                },
+                unkown_event => {
+                    dbg!(unkown_event);
+                }
+            }
+        }
+    }
+}
+
+impl eframe::App for DSExampleGUI {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        self.poll_updates();
+
+        egui::TopBottomPanel::top("top_bar").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.selectable_value(&mut self.current_tab, Tab::EffectRack, "FX Rack");
+                ui.selectable_value(&mut self.current_tab, Tab::ScannedPlugins, "Scanned Plugins");
+
+                ui.with_layout(egui::Layout::right_to_left(), |ui| {
+                    if let Some(state) = &self.engine_state {
+                        ui.label(format!("sample rate: {}", self.sample_rate.as_u16()));
+                        ui.colored_label(egui::Color32::GREEN, "active");
+                        ui.label("engine status:");
+
+                        if ui.button("deactivate").clicked() {
+                            self.engine_handle.send(DSEngineRequest::DeactivateEngine);
+                        }
+                    } else {
+                        ui.colored_label(egui::Color32::RED, "inactive");
+                        ui.label("engine status:");
+
+                        if ui.button("activate").clicked() {
+                            self.engine_handle.send(DSEngineRequest::ActivateEngine(Box::new(
+                                ActivateEngineSettings {
+                                    sample_rate: self.sample_rate,
+                                    min_frames: MIN_BLOCK_SIZE,
+                                    max_frames: MAX_BLOCK_SIZE,
+                                    num_audio_in_channels: GRAPH_IN_CHANNELS,
+                                    num_audio_out_channels: GRAPH_OUT_CHANNELS,
+                                    ..Default::default()
+                                },
+                            )));
+                        }
+                    }
+                });
+            });
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| match self.current_tab {
+            Tab::EffectRack => effect_rack_page::show(self, ui),
+            Tab::ScannedPlugins => scanned_plugins_page::show(self, ui),
+        });
+    }
+
+    fn on_exit(&mut self, _gl: &eframe::glow::Context) {
+        self._cpal_stream = None;
+    }
+}
+
+#[derive(PartialEq)]
+enum Tab {
+    EffectRack,
+    ScannedPlugins,
+}

--- a/examples/test-host/src/scanned_plugins_page.rs
+++ b/examples/test-host/src/scanned_plugins_page.rs
@@ -1,0 +1,65 @@
+use eframe::egui;
+
+use dropseed::DSEngineRequest;
+
+use super::DSExampleGUI;
+
+pub(crate) fn show(app: &mut DSExampleGUI, ui: &mut egui::Ui) {
+    // TODO: Add/remove plugin paths.
+
+    if ui.button("Rescan all plugin directories").clicked() {
+        app.engine_handle.send(DSEngineRequest::RescanPluginDirectories);
+    }
+
+    ui.separator();
+
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        ui.heading("Available Plugins");
+        egui::ScrollArea::horizontal().id_source("available_plugs_hscroll").show(ui, |ui| {
+            egui::Grid::new("available_plugs").num_columns(10).striped(true).show(ui, |ui| {
+                ui.label("NAME");
+                ui.label("VERSION");
+                ui.label("VENDOR");
+                ui.label("FORMAT");
+                ui.label("FORMAT VERSION");
+                ui.label("DESCRIPTION");
+                ui.label("RDN");
+                ui.label("URL");
+                ui.label("MANUAL URL");
+                ui.label("SUPPORT URL");
+                ui.end_row();
+
+                for plugin in app.plugin_list.iter() {
+                    ui.label(&plugin.0.description.name);
+                    ui.label(&plugin.0.description.version);
+                    ui.label(&plugin.0.description.vendor);
+                    ui.label(format!("{}", plugin.0.format));
+                    ui.label(&plugin.0.format_version);
+                    ui.label(&plugin.0.description.description);
+                    ui.label(&plugin.0.description.id);
+                    ui.label(&plugin.0.description.url);
+                    ui.label(&plugin.0.description.manual_url);
+                    ui.label(&plugin.0.description.support_url);
+                    ui.end_row();
+                }
+            });
+        });
+
+        ui.separator();
+
+        ui.heading("Failed Plugin Errors");
+        egui::ScrollArea::horizontal().id_source("failed_plugs_hscroll").show(ui, |ui| {
+            egui::Grid::new("failed_plugs").num_columns(2).striped(true).show(ui, |ui| {
+                ui.label("PATH");
+                ui.label("ERROR");
+                ui.end_row();
+
+                for (path, error) in app.failed_plugins_text.iter() {
+                    ui.label(path);
+                    ui.label(error);
+                    ui.end_row();
+                }
+            });
+        });
+    });
+}

--- a/src/clap/plugin.rs
+++ b/src/clap/plugin.rs
@@ -117,7 +117,7 @@ impl ClapPluginMainThread {
         }).collect();
 
         let outputs: Vec<AudioPortInfo> = (0..num_out_ports).filter_map(|i| {
-            let raw_info = match audio_ports.get(&plugin, i, true, &mut buffer) {
+            let raw_info = match audio_ports.get(&plugin, i, false, &mut buffer) {
                 None => {
                     log::warn!("Error when getting CLAP Port Info from plugin instance {}: plugin returned no info for index {}", id, i);
                     return None;
@@ -151,7 +151,7 @@ impl ClapPluginMainThread {
             })
         }).collect();
 
-        let main_ports_layout = match (has_main_in_port, has_main_in_port) {
+        let main_ports_layout = match (has_main_in_port, has_main_out_port) {
             (true, true) => MainPortsLayout::InOut,
             (true, false) => MainPortsLayout::InOnly,
             (false, true) => MainPortsLayout::OutOnly,


### PR DESCRIPTION
This PR does the following:

* Add `dropseed-example` as an example inside the repository, so that it can be developed and tested alongside it.
* Remove the dependency on `libloading`: this is a missed artifact of the previous PR, since now all libloading operations are handled by Clack
* Add a Github-Actions CI workflow, which checks the following (on both PRs and normal commits):
  * Run all tests in a [windows, macos, ubuntu] x [stable, beta, nightly] matrix
  * Run the ubuntu x nightly tests through MIRI
  * Check if the code complies to both Clippy and Rustfmt

Clippy only fails on hard errors for now, as there are quite a few of warnings to fix right now, and this PR is big enough :)