### PR TITLE
Finalize Clack migration by removing clap-sys direct dependency and CLAP-related unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,8 @@ cpal-asio = ["cpal/asio"]
 [dependencies]
 meadowlark-core-types = { git = "https://github.com/MeadowlarkDAW/meadowlark-core-types", branch = "main" }
 audio-graph = { git = "https://github.com/MeadowlarkDAW/audio-graph", branch = "main" }
-clap-sys = "0.3.0"
 clack-host = { git = "https://github.com/prokopyl/clack" }
-clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "log", "params", "state", "thread-check"] }
+clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "log", "note-ports", "params", "state", "thread-check"] }
 dirs = { version = "4.0", optional = true }
 raw-window-handle = "0.4"
 basedrop = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ cpal-asio = ["cpal/asio"]
 [dependencies]
 meadowlark-core-types = { git = "https://github.com/MeadowlarkDAW/meadowlark-core-types", branch = "main" }
 audio-graph = { git = "https://github.com/MeadowlarkDAW/audio-graph", branch = "main" }
-clack-host = { git = "https://github.com/prokopyl/clack" }
-clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "log", "note-ports", "params", "state", "thread-check"] }
+clack-host = { git = "https://github.com/prokopyl/clack", rev = "46574a236306ded5afadc5285080faf65b99e26e" }
+clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "log", "note-ports", "params", "state", "thread-check"], rev = "46574a236306ded5afadc5285080faf65b99e26e" }
 dirs = { version = "4.0", optional = true }
 raw-window-handle = "0.4"
 basedrop = "0.1"

--- a/examples/test-host/src/effect_rack_page.rs
+++ b/examples/test-host/src/effect_rack_page.rs
@@ -334,19 +334,17 @@ pub(crate) fn show_effect_rack_plugin(
                                         values_to_set.push((param.id, value as f64));
                                         param.value = value as f64;
                                     }
-                                } else {
-                                    if ui
-                                        .add(
-                                            egui::Slider::new(
-                                                &mut param.value,
-                                                param.min_value..=param.max_value,
-                                            )
-                                            .text(&param.display_name),
+                                } else if ui
+                                    .add(
+                                        egui::Slider::new(
+                                            &mut param.value,
+                                            param.min_value..=param.max_value,
                                         )
-                                        .changed()
-                                    {
-                                        values_to_set.push((param.id, param.value))
-                                    }
+                                        .text(&param.display_name),
+                                    )
+                                    .changed()
+                                {
+                                    values_to_set.push((param.id, param.value))
                                 }
 
                                 if param.is_gesturing {

--- a/src/clap/plugin.rs
+++ b/src/clap/plugin.rs
@@ -16,7 +16,6 @@ use clack_extensions::thread_check::ThreadCheck;
 use clack_host::events::io::{InputEvents, OutputEvents};
 use clack_host::extensions::HostExtensions;
 use clack_host::host::{Host, HostAudioProcessor, HostMainThread, HostShared};
-use clap_sys::string_sizes::CLAP_NAME_SIZE;
 use meadowlark_core_types::SampleRate;
 use std::ffi::CString;
 use std::io::Cursor;
@@ -376,7 +375,7 @@ impl PluginMainThread for ClapPluginMainThread {
     #[allow(unused)]
     fn param_value_to_text(&self, param_id: ParamID, value: f64) -> Result<String, ()> {
         if let Some(params_ext) = self.instance.shared_host_data().params_ext {
-            let mut char_buf = [MaybeUninit::uninit(); CLAP_NAME_SIZE];
+            let mut char_buf = [MaybeUninit::uninit(); 256];
 
             let bytes = params_ext
                 .value_to_text(&self.instance, param_id.0, value, &mut char_buf)

--- a/src/clap/plugin.rs
+++ b/src/clap/plugin.rs
@@ -230,7 +230,7 @@ impl PluginMainThread for ClapPluginMainThread {
         if let Some(state_ext) = self.instance.shared_host_data().state_ext {
             let mut buffer = Vec::new();
 
-            state_ext.save(self.instance.main_thread_plugin_data(), &mut buffer).map_err(|e| {
+            state_ext.save(self.instance.main_thread_plugin_data(), &mut buffer).map_err(|_| {
                 format!(
                     "Plugin with ID {} returned error on call to clap_plugin_state.save()",
                     &*self.id()
@@ -239,7 +239,7 @@ impl PluginMainThread for ClapPluginMainThread {
 
             Ok(Some(buffer))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 
@@ -252,7 +252,7 @@ impl PluginMainThread for ClapPluginMainThread {
         if let Some(state_ext) = self.instance.shared_host_data().state_ext {
             let mut reader = Cursor::new(&preset.bytes);
 
-            state_ext.load(self.instance.main_thread_plugin_data(), &mut reader).map_err(|e| {
+            state_ext.load(self.instance.main_thread_plugin_data(), &mut reader).map_err(|_| {
                 format!(
                     "Plugin with ID {} returned error on call to clap_plugin_state.load()",
                     &*self.id()

--- a/src/clap/plugin.rs
+++ b/src/clap/plugin.rs
@@ -517,6 +517,7 @@ impl PluginAudioThread for ClapPluginAudioThread {
                     &mut out_events,
                     proc_info.steady_time,
                     Some(proc_info.frames),
+                    None,
                 );
 
             //#[cfg(debug_assertions)]

--- a/src/engine/audio_thread.rs
+++ b/src/engine/audio_thread.rs
@@ -74,7 +74,7 @@ impl DSEngineAudioThread {
         let num_frames_wanted =
             if in_channels == 0 { Some(Arc::new(AtomicU32::new(0))) } else { None };
 
-        let num_frames_wanted_clone = num_frames_wanted.as_ref().map(|n| Arc::clone(n));
+        let num_frames_wanted_clone = num_frames_wanted.as_ref().map(Arc::clone);
 
         let sample_rate_recip = 1.0 / sample_rate.as_f64();
 

--- a/src/engine/main_thread.rs
+++ b/src/engine/main_thread.rs
@@ -90,7 +90,7 @@ impl DSEngineMainThread {
             while let Ok(msg) = self.handle_to_engine_rx.try_recv() {
                 match msg {
                     DSEngineRequest::ModifyGraph(req) => self.modify_graph(req),
-                    DSEngineRequest::ActivateEngine(settings) => self.activate_engine(settings),
+                    DSEngineRequest::ActivateEngine(settings) => self.activate_engine(&settings),
                     DSEngineRequest::DeactivateEngine => self.deactivate_engine(),
                     DSEngineRequest::RestoreFromSaveState(save_state) => {
                         self.restore_audio_graph_from_save_state(&save_state)
@@ -164,7 +164,7 @@ impl DSEngineMainThread {
         self.event_tx.send(PluginScannerEvent::RescanFinished(res).into()).unwrap();
     }
 
-    fn activate_engine(&mut self, settings: Box<ActivateEngineSettings>) {
+    fn activate_engine(&mut self, settings: &ActivateEngineSettings) {
         if self.audio_graph.is_some() {
             log::warn!("Ignored request to activate RustyDAW engine: Engine is already activated");
             return;
@@ -350,7 +350,7 @@ impl DSEngineMainThread {
                     PluginIDReq::Existing(id) => id,
                 };
 
-                if let Err(e) = audio_graph.connect_edge(&edge, src_plugin_id, dst_plugin_id) {
+                if let Err(e) = audio_graph.connect_edge(edge, src_plugin_id, dst_plugin_id) {
                     if edge.log_error_on_fail {
                         log::error!("Could not connect edge: {}", e);
                     }

--- a/src/engine/process_thread.rs
+++ b/src/engine/process_thread.rs
@@ -97,15 +97,11 @@ impl DSEngineProcessThread {
                     let (slice_1, slice_2) = chunk.as_mut_slices();
 
                     let out_part = &self.out_temp_buffer[0..slice_1.len()];
-                    for i in 0..slice_1.len() {
-                        slice_1[i] = out_part[i];
-                    }
+                    slice_1.copy_from_slice(&out_part[..slice_1.len()]);
 
                     let out_part =
                         &self.out_temp_buffer[slice_1.len()..slice_1.len() + slice_2.len()];
-                    for i in 0..slice_2.len() {
-                        slice_2[i] = out_part[i];
-                    }
+                    slice_2.copy_from_slice(&out_part[..slice_2.len()]);
 
                     chunk.commit_all();
                 }

--- a/src/graph/compiler.rs
+++ b/src/graph/compiler.rs
@@ -415,11 +415,9 @@ pub(crate) fn compile_graph(
 
         let plugin_audio_thread = plugin_audio_thread.clone();
 
-        let task_version = plugin_audio_thread.task_version;
-
         tasks.push(Task::Plugin(PluginTask {
             plugin: plugin_audio_thread,
-            buffers: ProcBuffers { audio_in, audio_out, task_version },
+            buffers: ProcBuffers { audio_in, audio_out },
             automation_in_buffers,
             automation_out_buffer,
             note_in_buffers,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -324,7 +324,7 @@ impl AudioGraph {
             }
 
             if removed_plugins.insert(id.clone()) {
-                if let Ok(edges) = self.get_plugin_edges(&id) {
+                if let Ok(edges) = self.get_plugin_edges(id) {
                     for e in edges.incoming {
                         let _ = affected_plugins.insert(e.src_plugin_id.clone());
                     }
@@ -332,7 +332,7 @@ impl AudioGraph {
                         let _ = affected_plugins.insert(e.dst_plugin_id.clone());
                     }
 
-                    if let Some(plugin) = self.shared_plugin_pool.plugins.get_mut(&id) {
+                    if let Some(plugin) = self.shared_plugin_pool.plugins.get_mut(id) {
                         plugin.plugin_host.schedule_remove();
                     }
 
@@ -340,7 +340,7 @@ impl AudioGraph {
                         log::error!("Abstract node failed to delete node: {}", e);
                     }
                 } else {
-                    let _ = removed_plugins.remove(&id);
+                    let _ = removed_plugins.remove(id);
                     log::warn!("Ignored request to remove plugin instance {:?}: Plugin is already removed.", id);
                 }
             }
@@ -627,7 +627,7 @@ impl AudioGraph {
         for (index, (plugin_id, plugin_entry)) in
             self.shared_plugin_pool.plugins.iter_mut().enumerate()
         {
-            if let Some(_) = node_ref_to_index.insert(plugin_id.node_ref, index) {
+            if node_ref_to_index.insert(plugin_id.node_ref, index).is_some() {
                 // In theory this should never happen.
                 panic!("More than one plugin with node ref: {:?}", plugin_id.node_ref);
             }
@@ -792,10 +792,10 @@ impl AudioGraph {
             },
         );
         let _ = self.shared_plugin_pool.plugins.insert(
-            graph_out_node_id.clone(),
+            graph_out_node_id,
             PluginInstanceHostEntry {
                 plugin_host: PluginInstanceHost::new_graph_out(
-                    graph_in_node_id.clone(),
+                    graph_in_node_id,
                     HostRequest::new(Shared::clone(&self.host_info)),
                     self.graph_out_channels as usize,
                 ),
@@ -1006,7 +1006,7 @@ impl AudioGraph {
                 }
             }
 
-            if modified_params.len() > 0 {
+            if !modified_params.is_empty() {
                 if let Some(event_tx) = event_tx.as_ref() {
                     event_tx
                         .send(DSEngineEvent::Plugin(PluginEvent::ParamsModified {

--- a/src/graph/plugin/audio_buffer.rs
+++ b/src/graph/plugin/audio_buffer.rs
@@ -117,7 +117,7 @@ impl AudioPortBuffer {
     }
 
     #[inline]
-    pub fn channel<'a>(&'a self, index: usize) -> Option<MonoBuffer<'a>> {
+    pub fn channel(&self, index: usize) -> Option<MonoBuffer> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 b.get(index).map(|b| MonoBuffer::F32(b.buffer.data.borrow()))
@@ -129,7 +129,7 @@ impl AudioPortBuffer {
     }
 
     #[inline]
-    pub fn mono<'a>(&'a self) -> MonoBuffer<'a> {
+    pub fn mono(&self) -> MonoBuffer {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => MonoBuffer::F32(b[0].buffer.data.borrow()),
             RawAudioChannelBuffers::F64(b) => MonoBuffer::F64(b[0].buffer.data.borrow()),
@@ -137,7 +137,7 @@ impl AudioPortBuffer {
     }
 
     #[inline]
-    pub fn stereo<'a>(&'a self) -> Option<StereoBuffer<'a>> {
+    pub fn stereo(&self) -> Option<StereoBuffer> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 if b.len() > 1 {
@@ -157,7 +157,7 @@ impl AudioPortBuffer {
     }
 
     #[inline]
-    pub fn mono_f32<'a>(&'a self) -> Option<AtomicRef<'a, Vec<f32>>> {
+    pub fn mono_f32(&self) -> Option<AtomicRef<Vec<f32>>> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => Some(b[0].buffer.data.borrow()),
             _ => None,
@@ -165,7 +165,7 @@ impl AudioPortBuffer {
     }
 
     #[inline]
-    pub fn stereo_f32<'a>(&'a self) -> Option<(AtomicRef<'a, Vec<f32>>, AtomicRef<'a, Vec<f32>>)> {
+    pub fn stereo_f32(&self) -> Option<(AtomicRef<Vec<f32>>, AtomicRef<Vec<f32>>)> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 if b.len() > 1 {
@@ -318,7 +318,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn channel<'a>(&'a self, index: usize) -> Option<MonoBuffer<'a>> {
+    pub fn channel(&self, index: usize) -> Option<MonoBuffer> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 b.get(index).map(|b| MonoBuffer::F32(b.buffer.data.borrow()))
@@ -330,7 +330,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn channel_mut<'a>(&'a mut self, index: usize) -> Option<MonoBufferMut<'a>> {
+    pub fn channel_mut(&mut self, index: usize) -> Option<MonoBufferMut> {
         match &mut self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 b.get(index).map(|b| MonoBufferMut::F32(b.buffer.data.borrow_mut()))
@@ -342,7 +342,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn mono<'a>(&'a self) -> MonoBuffer<'a> {
+    pub fn mono(&self) -> MonoBuffer {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => MonoBuffer::F32(b[0].buffer.data.borrow()),
             RawAudioChannelBuffers::F64(b) => MonoBuffer::F64(b[0].buffer.data.borrow()),
@@ -350,7 +350,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn mono_mut<'a>(&'a mut self) -> MonoBufferMut<'a> {
+    pub fn mono_mut(&mut self) -> MonoBufferMut {
         match &mut self.raw_channels {
             RawAudioChannelBuffers::F32(b) => MonoBufferMut::F32(b[0].buffer.data.borrow_mut()),
             RawAudioChannelBuffers::F64(b) => MonoBufferMut::F64(b[0].buffer.data.borrow_mut()),
@@ -358,7 +358,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn stereo<'a>(&'a self) -> Option<StereoBuffer<'a>> {
+    pub fn stereo(&self) -> Option<StereoBuffer> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 if b.len() > 1 {
@@ -378,7 +378,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn stereo_mut<'a>(&'a mut self) -> Option<StereoBufferMut<'a>> {
+    pub fn stereo_mut(&mut self) -> Option<StereoBufferMut> {
         match &mut self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 if b.len() > 1 {
@@ -404,7 +404,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn channel_f32<'a>(&'a self, index: usize) -> Option<AtomicRef<'a, Vec<f32>>> {
+    pub fn channel_f32(&self, index: usize) -> Option<AtomicRef<Vec<f32>>> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => b.get(index).map(|b| b.buffer.data.borrow()),
             _ => None,
@@ -412,7 +412,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn channel_f32_mut<'a>(&'a mut self, index: usize) -> Option<AtomicRefMut<'a, Vec<f32>>> {
+    pub fn channel_f32_mut(&mut self, index: usize) -> Option<AtomicRefMut<Vec<f32>>> {
         match &mut self.raw_channels {
             RawAudioChannelBuffers::F32(b) => b.get_mut(index).map(|b| b.buffer.data.borrow_mut()),
             _ => None,
@@ -420,7 +420,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn mono_f32<'a>(&'a self) -> Option<AtomicRef<'a, Vec<f32>>> {
+    pub fn mono_f32(&self) -> Option<AtomicRef<Vec<f32>>> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => Some(b[0].buffer.data.borrow()),
             _ => None,
@@ -428,7 +428,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn mono_f32_mut<'a>(&'a mut self) -> Option<AtomicRefMut<'a, Vec<f32>>> {
+    pub fn mono_f32_mut(&mut self) -> Option<AtomicRefMut<Vec<f32>>> {
         match &mut self.raw_channels {
             RawAudioChannelBuffers::F32(b) => Some(b[0].buffer.data.borrow_mut()),
             _ => None,
@@ -436,7 +436,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn stereo_f32<'a>(&'a self) -> Option<(AtomicRef<'a, Vec<f32>>, AtomicRef<'a, Vec<f32>>)> {
+    pub fn stereo_f32(&self) -> Option<(AtomicRef<Vec<f32>>, AtomicRef<Vec<f32>>)> {
         match &self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 if b.len() > 1 {
@@ -450,9 +450,7 @@ impl AudioPortBufferMut {
     }
 
     #[inline]
-    pub fn stereo_f32_mut<'a>(
-        &'a mut self,
-    ) -> Option<(AtomicRefMut<'a, Vec<f32>>, AtomicRefMut<'a, Vec<f32>>)> {
+    pub fn stereo_f32_mut(&mut self) -> Option<(AtomicRefMut<Vec<f32>>, AtomicRefMut<Vec<f32>>)> {
         match &mut self.raw_channels {
             RawAudioChannelBuffers::F32(b) => {
                 if b.len() > 1 {

--- a/src/graph/plugin/ext/audio_ports.rs
+++ b/src/graph/plugin/ext/audio_ports.rs
@@ -1,9 +1,7 @@
-use bitflags::bitflags;
+pub const PORT_TYPE_MONO: &str = "mono";
+pub const PORT_TYPE_STEREO: &str = "stereo";
 
-pub const PORT_TYPE_MONO: &'static str = "mono";
-pub const PORT_TYPE_STEREO: &'static str = "stereo";
-
-pub const PORT_NAME_SIDECHAIN: &'static str = "sidechain";
+pub const PORT_NAME_SIDECHAIN: &str = "sidechain";
 
 pub(crate) static EMPTY_AUDIO_PORTS_CONFIG: PluginAudioPortsExt = PluginAudioPortsExt::empty();
 
@@ -365,27 +363,5 @@ pub enum MainPortsLayout {
 impl Default for MainPortsLayout {
     fn default() -> Self {
         MainPortsLayout::InOut
-    }
-}
-
-bitflags! {
-    pub struct AudioPortRescanFlags: u32 {
-        /// The ports name did change, the host can scan them right away.
-        const RESCAN_NAMES = clap_sys::ext::audio_ports::CLAP_AUDIO_PORTS_RESCAN_NAMES;
-
-        /// [!active] The flags did change
-        const RESCAN_FLAGS = clap_sys::ext::audio_ports::CLAP_AUDIO_PORTS_RESCAN_FLAGS;
-
-        /// [!active] The channel_count did change
-        const RESCAN_CHANNEL_COUNT = clap_sys::ext::audio_ports::CLAP_AUDIO_PORTS_RESCAN_CHANNEL_COUNT;
-
-        /// [!active] The port type did change
-        const RESCAN_PORT_TYPE = clap_sys::ext::audio_ports::CLAP_AUDIO_PORTS_RESCAN_PORT_TYPE;
-
-        /// [!active] The in-place pair did change, this requires.
-        const RESCAN_IN_PLACE_PAIR = clap_sys::ext::audio_ports::CLAP_AUDIO_PORTS_RESCAN_IN_PLACE_PAIR;
-
-        /// [!active] The list of ports have changed: entries have been removed/added.
-        const RESCAN_LIST = clap_sys::ext::audio_ports::CLAP_AUDIO_PORTS_RESCAN_LIST;
     }
 }

--- a/src/graph/plugin/ext/note_ports.rs
+++ b/src/graph/plugin/ext/note_ports.rs
@@ -2,27 +2,9 @@
 //! If the plugin does not implement this extension, it won't have note input or output.
 //! The plugin is only allowed to change its note ports configuration while it is deactivated.
 
-use bitflags::bitflags;
-
-use clap_sys::ext::note_ports::{
-    CLAP_NOTE_DIALECT_CLAP, CLAP_NOTE_DIALECT_MIDI, CLAP_NOTE_DIALECT_MIDI2,
-    CLAP_NOTE_DIALECT_MIDI_MPE, CLAP_NOTE_PORTS_RESCAN_ALL, CLAP_NOTE_PORTS_RESCAN_NAMES,
-};
+use clack_extensions::note_ports::{NoteDialect, NoteDialects};
 
 pub(crate) static EMPTY_NOTE_PORTS_CONFIG: PluginNotePortsExt = PluginNotePortsExt::empty();
-
-bitflags! {
-    pub struct NoteDialect: u32 {
-        /// Uses clap_event_note and clap_event_note_expression.
-        const CLAP = CLAP_NOTE_DIALECT_CLAP;
-        /// Uses clap_event_midi, no polyphonic expression
-        const MIDI = CLAP_NOTE_DIALECT_MIDI;
-        /// Uses clap_event_midi, with polyphonic expression (MPE)
-        const MIDI_MPE = CLAP_NOTE_DIALECT_MIDI_MPE;
-        /// Uses clap_event_midi2
-        const MIDI2 = CLAP_NOTE_DIALECT_MIDI2;
-    }
-}
 
 #[derive(Debug, Clone, PartialEq)]
 /// The layout of the audio ports of a plugin.
@@ -46,26 +28,11 @@ pub struct NotePortInfo {
     pub stable_id: u32,
 
     /// bitfield, see `NoteDialect`
-    pub supported_dialects: NoteDialect,
+    pub supported_dialects: NoteDialects,
 
     /// one value of `NoteDialect`
-    pub preferred_dialect: NoteDialect,
+    pub preferred_dialect: Option<NoteDialect>,
 
     /// displayable name
     pub display_name: Option<String>,
-}
-
-bitflags! {
-    pub struct NotePortRescanFlags: u32 {
-        /// The ports have changed, the host shall perform a full scan of the ports.
-        ///
-        /// This flag can only be used if the plugin is not active.
-        ///
-        /// If the plugin active, call host_request.request_restart() and then call rescan()
-        /// when the host calls deactivate()
-        const RESCAN_ALL = CLAP_NOTE_PORTS_RESCAN_ALL;
-
-        /// The ports name did change, the host can scan them right away.
-        const RESCAN_NAMES = CLAP_NOTE_PORTS_RESCAN_NAMES;
-    }
 }

--- a/src/graph/plugin/ext/params.rs
+++ b/src/graph/plugin/ext/params.rs
@@ -1,5 +1,5 @@
 use bitflags::bitflags;
-use std::ffi::c_void;
+use clack_host::utils::Cookie;
 use std::hash::Hash;
 use std::sync::{
     atomic::{AtomicBool, AtomicU32, Ordering},
@@ -131,17 +131,8 @@ pub struct ParamInfo {
 
     /// Reserved for CLAP plugins.
     #[allow(unused)]
-    pub(crate) cookie: *const c_void,
+    pub(crate) cookie: Cookie,
 }
-
-// This is necessary because this struct has a pointer which the CLAP plugin
-// owns (if it is a CLAP plugin). This should be safe since only the plugin
-// itself ever reads/writes to that pointer.
-unsafe impl Send for ParamInfo {}
-// This is necessary because this struct has a pointer which the CLAP plugin
-// owns (if it is a CLAP plugin). This should be safe since only the plugin
-// itself ever reads/writes to that pointer.
-unsafe impl Sync for ParamInfo {}
 
 impl ParamInfo {
     /// Create info for a parameter.
@@ -172,7 +163,7 @@ impl ParamInfo {
             min_value,
             max_value,
             default_value,
-            cookie: std::ptr::null(),
+            cookie: Cookie::empty(),
         }
     }
 }

--- a/src/graph/plugin/host_request.rs
+++ b/src/graph/plugin/host_request.rs
@@ -1,18 +1,15 @@
 use basedrop::Shared;
 use bitflags::bitflags;
-use std::ffi::{CStr, CString};
-use std::pin::Pin;
 use std::sync::{
     atomic::{AtomicU32, Ordering},
     Arc,
 };
 
+use clack_extensions::audio_ports::RescanType;
+use clack_extensions::note_ports::{NoteDialects, NotePortRescanFlags};
 use clack_host::host::HostInfo as ClackHostInfo;
 
 use crate::plugin::ext::params::HostParamsExtMainThread;
-
-use super::ext::audio_ports::AudioPortRescanFlags;
-use super::ext::note_ports::{NoteDialect, NotePortRescanFlags};
 
 #[derive(Debug, Clone)]
 pub struct HostInfo {
@@ -37,10 +34,6 @@ pub struct HostInfo {
     pub url: Option<String>,
 
     pub(crate) clack_host_info: ClackHostInfo,
-}
-
-fn to_pin_cstr(str: &str) -> Pin<Box<CStr>> {
-    Pin::new(CString::new(str).unwrap_or(CString::new("Error").unwrap()).into_boxed_c_str())
 }
 
 impl HostInfo {
@@ -144,7 +137,7 @@ impl HostRequest {
     /// Checks if the host allows a plugin to change a given aspect of the audio ports definition.
     ///
     /// [main-thread]
-    pub fn is_rescan_audio_ports_flag_supported(&self, flag: AudioPortRescanFlags) -> bool {
+    pub fn is_rescan_audio_ports_flag_supported(&self, _flag: RescanType) -> bool {
         // todo
         false
     }
@@ -152,9 +145,9 @@ impl HostRequest {
     /// Checks if the host allows a plugin to change a given aspect of the audio ports definition.
     ///
     /// [main-thread]
-    pub fn supported_note_dialects(&self) -> NoteDialect {
+    pub fn supported_note_dialects(&self) -> NoteDialects {
         // todo: more
-        NoteDialect::CLAP | NoteDialect::MIDI | NoteDialect::MIDI2
+        NoteDialects::CLAP | NoteDialects::MIDI | NoteDialects::MIDI2
     }
 
     /// Rescan the full list of audio ports according to the flags.
@@ -164,11 +157,11 @@ impl HostRequest {
     /// Certain flags require the plugin to be de-activated.
     ///
     /// [main-thread]
-    pub fn rescan_audio_ports(&self, flags: AudioPortRescanFlags) {
+    pub fn rescan_audio_ports(&self, _flags: RescanType) {
         // todo
     }
 
-    pub fn rescan_note_ports(&self, flags: NotePortRescanFlags) {
+    pub fn rescan_note_ports(&self, _flags: NotePortRescanFlags) {
         // todo
     }
 

--- a/src/graph/plugin/process_info.rs
+++ b/src/graph/plugin/process_info.rs
@@ -48,9 +48,6 @@ pub struct ProcInfo {
 pub struct ProcBuffers {
     pub audio_in: SmallVec<[AudioPortBuffer; 2]>,
     pub audio_out: SmallVec<[AudioPortBufferMut; 2]>,
-
-    /// Used to let external plugins know when it should update its list of buffers.
-    pub(crate) task_version: u64,
 }
 
 impl ProcBuffers {

--- a/src/graph/plugin_host.rs
+++ b/src/graph/plugin_host.rs
@@ -3,6 +3,7 @@ use clack_host::events::event_types::{ParamModEvent, ParamValueEvent};
 use clack_host::events::io::EventBuffer;
 use clack_host::events::spaces::CoreEventSpace;
 use clack_host::events::{Event, EventFlags, EventHeader};
+use clack_host::utils::Cookie;
 use fnv::FnvHashMap;
 use meadowlark_core_types::SampleRate;
 use smallvec::SmallVec;
@@ -32,17 +33,8 @@ use crate::{HostRequest, ParamID, ProcInfo, ProcessStatus, ScannedPluginKey};
 #[derive(Clone, Copy)]
 struct MainToAudioParamValue {
     value: f64,
-    _cookie: *const std::ffi::c_void,
+    _cookie: Cookie,
 }
-
-// This is necessary because this event has a pointer which the CLAP plugin
-// owns (if it is a CLAP plugin). This should be safe since only the plugin
-// itself ever reads/writes to that pointer.
-unsafe impl Sync for MainToAudioParamValue {}
-// This is necessary because this event has a pointer which the CLAP plugin
-// owns (if it is a CLAP plugin). This should be safe since only the plugin
-// itself ever reads/writes to that pointer.
-unsafe impl Send for MainToAudioParamValue {}
 
 impl ReducFnvValue for MainToAudioParamValue {}
 
@@ -748,7 +740,7 @@ impl PluginInstanceHostAudioThread {
                 let event = ParamValueEvent::new(
                     // TODO: Finer values for `time` instead of just setting it to the first frame?
                     EventHeader::new_core(0, EventFlags::empty()),
-                    core::ptr::null_mut(),
+                    Cookie::empty(),
                     // TODO: Note ID
                     -1,                // note_id
                     param_id.as_u32(), // param_id
@@ -770,7 +762,7 @@ impl PluginInstanceHostAudioThread {
                 let event = ParamModEvent::new(
                     // TODO: Finer values for `time` instead of just setting it to the first frame?
                     EventHeader::new_core(0, EventFlags::empty()),
-                    core::ptr::null_mut(),
+                    Cookie::empty(),
                     // TODO: Note ID
                     -1,                // note_id
                     param_id.as_u32(), // param_id

--- a/src/graph/save_state.rs
+++ b/src/graph/save_state.rs
@@ -13,14 +13,8 @@ pub struct EdgeSaveState {
     pub dst_port_channel: u16,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AudioGraphSaveState {
     pub plugins: Vec<PluginSaveState>,
     pub edges: Vec<EdgeSaveState>,
-}
-
-impl Default for AudioGraphSaveState {
-    fn default() -> Self {
-        AudioGraphSaveState { plugins: Vec::new(), edges: Vec::new() }
-    }
 }

--- a/src/graph/schedule/mod.rs
+++ b/src/graph/schedule/mod.rs
@@ -121,8 +121,8 @@ impl Schedule {
 
                     let mut is_constant = true;
                     let first_val = buffer[0];
-                    for i in 0..frames {
-                        if buffer[i] != first_val {
+                    for frame in &buffer[0..frames] {
+                        if *frame != first_val {
                             is_constant = false;
                             break;
                         }

--- a/src/graph/schedule/sum.rs
+++ b/src/graph/schedule/sum.rs
@@ -40,7 +40,7 @@ impl SumTask {
 
                 let in_0 = &in_0_ref[0..proc_info.frames];
 
-                out.copy_from_slice(&in_0);
+                out.copy_from_slice(in_0);
             }
             2 => {
                 let in_0_ref = self.audio_in[0].borrow();

--- a/src/graph/schedule/task.rs
+++ b/src/graph/schedule/task.rs
@@ -56,18 +56,16 @@ impl std::fmt::Debug for Task {
                 if !t.note_in_buffers.is_empty() {
                     let mut has_buffer = false;
                     let mut s = String::new();
-                    for buffers in t.note_in_buffers.iter() {
-                        if let Some(buffers) = buffers {
-                            has_buffer = true;
+                    for buffers in t.note_in_buffers.iter().flatten() {
+                        has_buffer = true;
 
-                            s.push_str("[");
+                        s.push('[');
 
-                            for b in buffers.iter() {
-                                s.push_str(&format!("{:?}, ", b.id()))
-                            }
-
-                            s.push_str("], ");
+                        for b in buffers.iter() {
+                            s.push_str(&format!("{:?}, ", b.id()))
                         }
+
+                        s.push_str("], ");
                     }
 
                     if has_buffer {
@@ -78,12 +76,10 @@ impl std::fmt::Debug for Task {
                 if !t.note_out_buffers.is_empty() {
                     let mut has_buffer = false;
                     let mut s = String::new();
-                    for buffer in t.note_out_buffers.iter() {
-                        if let Some(b) = buffer {
-                            has_buffer = true;
+                    for buffer in t.note_out_buffers.iter().flatten() {
+                        has_buffer = true;
 
-                            s.push_str(&format!("{:?}, ", b.id()));
-                        }
+                        s.push_str(&format!("{:?}, ", buffer.id()));
                     }
 
                     if has_buffer {
@@ -137,12 +133,10 @@ impl std::fmt::Debug for Task {
                 if !t.note_out_buffers.is_empty() {
                     let mut has_buffer = false;
                     let mut s = String::new();
-                    for buffer in t.note_out_buffers.iter() {
-                        if let Some(b) = buffer {
-                            has_buffer = true;
+                    for buffer in t.note_out_buffers.iter().flatten() {
+                        has_buffer = true;
 
-                            s.push_str(&format!("{:?}, ", b.id()));
-                        }
+                        s.push_str(&format!("{:?}, ", buffer.id()));
                     }
 
                     if has_buffer {
@@ -241,11 +235,9 @@ impl DeactivatedPluginTask {
             let mut b = out_buf.borrow_mut();
             b.clear();
         }
-        for out_buf in self.note_out_buffers.iter() {
-            if let Some(out_buf) = out_buf {
-                let mut b = out_buf.borrow_mut();
-                b.clear();
-            }
+        for out_buf in self.note_out_buffers.iter().flatten() {
+            let mut b = out_buf.borrow_mut();
+            b.clear();
         }
     }
 }

--- a/src/graph/shared_pool.rs
+++ b/src/graph/shared_pool.rs
@@ -90,12 +90,12 @@ pub(crate) struct SharedBuffer<T: Clone + Copy + Send + 'static> {
 
 impl<T: Clone + Copy + Send + 'static> SharedBuffer<T> {
     #[inline]
-    pub fn borrow<'a>(&'a self) -> AtomicRef<'a, Vec<T>> {
+    pub fn borrow(&self) -> AtomicRef<Vec<T>> {
         self.buffer.data.borrow()
     }
 
     #[inline]
-    pub fn borrow_mut<'a>(&'a self) -> AtomicRefMut<'a, Vec<T>> {
+    pub fn borrow_mut(&self) -> AtomicRefMut<Vec<T>> {
         self.buffer.data.borrow_mut()
     }
 
@@ -254,12 +254,11 @@ impl Hash for PluginInstanceID {
 
 pub(crate) struct SharedPluginHostAudioThread {
     pub plugin: Shared<AtomicRefCell<PluginInstanceHostAudioThread>>,
-    pub task_version: u64,
 }
 
 impl SharedPluginHostAudioThread {
     pub fn new(plugin: PluginInstanceHostAudioThread, coll_handle: &basedrop::Handle) -> Self {
-        Self { plugin: Shared::new(coll_handle, AtomicRefCell::new(plugin)), task_version: 0 }
+        Self { plugin: Shared::new(coll_handle, AtomicRefCell::new(plugin)) }
     }
 }
 
@@ -271,7 +270,7 @@ impl SharedPluginHostAudioThread {
 
 impl Clone for SharedPluginHostAudioThread {
     fn clone(&self) -> Self {
-        Self { plugin: Shared::clone(&self.plugin), task_version: self.task_version + 1 }
+        Self { plugin: Shared::clone(&self.plugin) }
     }
 }
 

--- a/src/graph/verifier.rs
+++ b/src/graph/verifier.rs
@@ -49,7 +49,7 @@ impl Verifier {
                 Task::Plugin(t) => {
                     if !self.plugin_instances.insert(t.plugin.id().node_ref) {
                         return Err(VerifyScheduleError::PluginInstanceAppearsTwiceInSchedule {
-                            plugin_id: t.plugin.id().clone(),
+                            plugin_id: t.plugin.id(),
                         });
                     }
 
@@ -60,7 +60,7 @@ impl Verifier {
                                     if !self.buffer_instances.insert(b.buffer.debug_id) {
                                         return Err(
                                             VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                                buffer_id: b.buffer.debug_id.clone(),
+                                                buffer_id: b.buffer.debug_id,
                                                 task_info: format!("{:?}", &task),
                                             },
                                         );
@@ -72,7 +72,7 @@ impl Verifier {
                                     if !self.buffer_instances.insert(b.buffer.debug_id) {
                                         return Err(
                                             VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                                buffer_id: b.buffer.debug_id.clone(),
+                                                buffer_id: b.buffer.debug_id,
                                                 task_info: format!("{:?}", &task),
                                             },
                                         );
@@ -89,7 +89,7 @@ impl Verifier {
                                     if !self.buffer_instances.insert(b.buffer.debug_id) {
                                         return Err(
                                             VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                                buffer_id: b.buffer.debug_id.clone(),
+                                                buffer_id: b.buffer.debug_id,
                                                 task_info: format!("{:?}", &task),
                                             },
                                         );
@@ -101,7 +101,7 @@ impl Verifier {
                                     if !self.buffer_instances.insert(b.buffer.debug_id) {
                                         return Err(
                                             VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                                buffer_id: b.buffer.debug_id.clone(),
+                                                buffer_id: b.buffer.debug_id,
                                                 task_info: format!("{:?}", &task),
                                             },
                                         );
@@ -114,7 +114,7 @@ impl Verifier {
                 Task::DelayComp(t) => {
                     if t.audio_in.buffer.debug_id == t.audio_out.buffer.debug_id {
                         return Err(VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                            buffer_id: t.audio_in.buffer.debug_id.clone(),
+                            buffer_id: t.audio_in.buffer.debug_id,
                             task_info: format!("{:?}", &task),
                         });
                     }
@@ -136,14 +136,14 @@ impl Verifier {
                     for b in t.audio_in.iter() {
                         if !self.buffer_instances.insert(b.buffer.debug_id) {
                             return Err(VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                buffer_id: b.buffer.debug_id.clone(),
+                                buffer_id: b.buffer.debug_id,
                                 task_info: format!("{:?}", &task),
                             });
                         }
                     }
                     if !self.buffer_instances.insert(t.audio_out.buffer.debug_id) {
                         return Err(VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                            buffer_id: t.audio_out.buffer.debug_id.clone(),
+                            buffer_id: t.audio_out.buffer.debug_id,
                             task_info: format!("{:?}", &task),
                         });
                     }
@@ -152,13 +152,13 @@ impl Verifier {
                     for (b_in, b_out) in t.audio_through.iter() {
                         if !self.buffer_instances.insert(b_in.buffer.debug_id) {
                             return Err(VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                buffer_id: b_in.buffer.debug_id.clone(),
+                                buffer_id: b_in.buffer.debug_id,
                                 task_info: format!("{:?}", &task),
                             });
                         }
                         if !self.buffer_instances.insert(b_out.buffer.debug_id) {
                             return Err(VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                buffer_id: b_out.buffer.debug_id.clone(),
+                                buffer_id: b_out.buffer.debug_id,
                                 task_info: format!("{:?}", &task),
                             });
                         }
@@ -167,7 +167,7 @@ impl Verifier {
                     for b in t.extra_audio_out.iter() {
                         if !self.buffer_instances.insert(b.buffer.debug_id) {
                             return Err(VerifyScheduleError::BufferAppearsTwiceInSameTask {
-                                buffer_id: b.buffer.debug_id.clone(),
+                                buffer_id: b.buffer.debug_id,
                                 task_info: format!("{:?}", &task),
                             });
                         }

--- a/src/plugins/sample_browser.rs
+++ b/src/plugins/sample_browser.rs
@@ -97,9 +97,6 @@ enum ProcessMsg {
     DiscardSample,
 }
 
-//unsafe impl Send for ProcessMsg {}
-//unsafe impl Sync for ProcessMsg {}
-
 struct ParamsHandle {
     pub gain: ParamF32Handle,
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -143,7 +143,7 @@ impl TransportTask {
 
         let playhead_frame = tempo_map.musical_to_nearest_frame_round(save_state.seek_to);
         let playhead_frame_shared = Arc::new(AtomicU64::new(playhead_frame.0));
-        let loop_state = save_state.loop_state.to_proc(&tempo_map);
+        let loop_state = save_state.loop_state.as_proc_info(&tempo_map);
 
         let (loop_start_beats, loop_end_beats, loop_start_seconds, loop_end_seconds) =
             if let LoopState::Active { loop_start, loop_end } = &save_state.loop_state {
@@ -559,7 +559,7 @@ pub enum LoopState {
 }
 
 impl LoopState {
-    fn to_proc(&self, tempo_map: &TempoMap) -> LoopStateProcInfo {
+    fn as_proc_info(&self, tempo_map: &TempoMap) -> LoopStateProcInfo {
         match self {
             LoopState::Inactive => LoopStateProcInfo::Inactive,
             &LoopState::Active { loop_start, loop_end } => LoopStateProcInfo::Active {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -370,18 +370,18 @@ impl TransportTask {
 
                 flags: transport_flags,
 
-                song_pos_beats: song_pos_beats.to_bits(),
-                song_pos_seconds: song_pos_seconds.to_bits(),
+                song_pos_beats,
+                song_pos_seconds,
 
                 tempo: self.tempo,
                 tempo_inc,
 
-                loop_start_beats: self.loop_start_beats.to_bits(),
-                loop_end_beats: self.loop_end_beats.to_bits(),
-                loop_start_seconds: self.loop_start_seconds.to_bits(),
-                loop_end_seconds: self.loop_end_seconds.to_bits(),
+                loop_start_beats: self.loop_start_beats,
+                loop_end_beats: self.loop_end_beats,
+                loop_start_seconds: self.loop_start_seconds,
+                loop_end_seconds: self.loop_end_seconds,
 
-                bar_start: self.bar_start.to_bits(),
+                bar_start: self.bar_start,
                 bar_number: self.bar_number,
 
                 time_signature_numerator: self.tsig_num as i16,

--- a/src/transport/tempo_map.rs
+++ b/src/transport/tempo_map.rs
@@ -49,25 +49,25 @@ impl TempoMap {
         }
     }
 
-    pub fn bpm_at_musical_time(&self, musical_time: MusicalTime) -> f64 {
+    pub fn bpm_at_musical_time(&self, _musical_time: MusicalTime) -> f64 {
         // temporary static tempo
         self.beats_per_second * 60.0
     }
 
     /// `(tempo in bpm, tempo increment for each sample until the next time info event)
-    pub fn bpm_at_frame(&self, frame: Frames) -> (f64, f64) {
+    pub fn bpm_at_frame(&self, _frame: Frames) -> (f64, f64) {
         // temporary static tempo
         (self.beats_per_second * 60.0, 0.0)
     }
 
     /// `(numerator, denomitator)`
-    pub fn tsig_at_musical_time(&self, musical_time: MusicalTime) -> (u16, u16) {
+    pub fn tsig_at_musical_time(&self, _musical_time: MusicalTime) -> (u16, u16) {
         // temporary static time signature
         (self.tsig_num, self.tsig_denom)
     }
 
     /// `(numerator, denomitator)`
-    pub fn tsig_at_frame(&self, frame: Frames) -> (u16, u16) {
+    pub fn tsig_at_frame(&self, _frame: Frames) -> (u16, u16) {
         // temporary static time signature
         (self.tsig_num, self.tsig_denom)
     }


### PR DESCRIPTION
This PR removes what was left of the code that was relying on `clap-sys` and CLAP-related unsafe code.

Since CI is enabled in this branch, I also took the opportunity to clean up a few easy Clippy lints. :slightly_smiling_face: