### PR TITLE
Support geting output constant flags from CLAP plugins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ cpal-asio = ["cpal/asio"]
 [dependencies]
 dropseed-plugin-api = { path = "./plugin-api" }
 audio-graph = { git = "https://github.com/MeadowlarkDAW/audio-graph", rev = "39a347ca8b00b092139728129c089b472b93ea8a" }
-clack-host = { git = "https://github.com/prokopyl/clack", rev = "31d247c00ddc228bc0a395c50f0738b3c91f409c" }
-clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "gui", "log", "note-ports", "params", "state", "thread-check", "latency", "timer"], rev = "31d247c00ddc228bc0a395c50f0738b3c91f409c" }
+clack-host = { git = "https://github.com/prokopyl/clack", rev = "43424685b7c0dd174fc7e9540a3903702cbda88d" }
+clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "gui", "log", "note-ports", "params", "state", "thread-check", "latency", "timer"], rev = "43424685b7c0dd174fc7e9540a3903702cbda88d" }
 dirs = { version = "4.0", optional = true }
 basedrop = "0.1"
 smallvec = { version = "1.9.0", features = ["const_generics", "union"] }

--- a/plugin-api/Cargo.toml
+++ b/plugin-api/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clack-host = { git = "https://github.com/prokopyl/clack", rev = "31d247c00ddc228bc0a395c50f0738b3c91f409c" }
-clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "gui", "log", "note-ports", "params", "state", "thread-check", "latency", "timer"], rev = "31d247c00ddc228bc0a395c50f0738b3c91f409c" }
+clack-host = { git = "https://github.com/prokopyl/clack", rev = "43424685b7c0dd174fc7e9540a3903702cbda88d" }
+clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "audio-ports", "gui", "log", "note-ports", "params", "state", "thread-check", "latency", "timer"], rev = "43424685b7c0dd174fc7e9540a3903702cbda88d" }
 basedrop = "0.1"
 smallvec = "1.7"
 bitflags = "1.3"

--- a/src/plugin_host/external/clap/factory.rs
+++ b/src/plugin_host/external/clap/factory.rs
@@ -9,11 +9,11 @@ use dropseed_plugin_api::HostRequestChannelSender;
 use dropseed_plugin_api::{
     HostInfo, PluginDescriptor, PluginFactory, PluginInstanceID, PluginMainThread,
 };
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::path::PathBuf;
 
 pub(crate) struct ClapPluginFactory {
-    pub clap_version: clack_host::version::ClapVersion,
+    pub clap_version: clack_host::utils::ClapVersion,
 
     bundle: PluginBundle,
     descriptor: PluginDescriptor,
@@ -47,6 +47,7 @@ impl PluginFactory for ClapPluginFactory {
 
         // TODO: this is a little wasteful, the PluginHost should be able to fit somewhere else
         let host = host_info.clack_host_info.clone();
+        let clap_plugin_id = CString::new(self.id.as_bytes()).map_err(|e| e.to_string())?;
 
         let raw_plugin = match PluginInstance::new(
             |_| {
@@ -60,11 +61,11 @@ impl PluginFactory for ClapPluginFactory {
             },
             |shared| ClapHostMainThread::new(shared),
             &self.bundle,
-            self.id.as_bytes(),
+            &clap_plugin_id,
             &host,
         ) {
             Ok(plugin) => plugin,
-            Err(e) => return Err(format!("{}", e)),
+            Err(e) => return Err(e.to_string()),
         };
 
         Ok(Box::new(ClapPluginMainThread::new(raw_plugin)?))
@@ -127,7 +128,7 @@ pub(crate) fn entry_init(
 }
 
 fn parse_clap_plugin_descriptor(
-    raw: Option<clack_host::bundle::PluginDescriptor>,
+    raw: Option<clack_host::factory::PluginDescriptor>,
     plugin_path: &PathBuf,
     plugin_index: usize,
 ) -> Result<PluginDescriptor, String> {

--- a/src/plugin_host/external/clap/host.rs
+++ b/src/plugin_host/external/clap/host.rs
@@ -3,28 +3,25 @@ use basedrop::Shared;
 use clack_extensions::audio_ports::HostAudioPorts;
 use clack_extensions::gui::{HostGui, PluginGui};
 use clack_extensions::latency::{HostLatency, PluginLatency};
-use clack_extensions::log::Log;
+use clack_extensions::log::HostLog;
 use clack_extensions::params::{HostParams, PluginParams};
 use clack_extensions::state::PluginState;
 use clack_extensions::thread_check::ThreadCheck;
 use clack_extensions::timer::{HostTimer, PluginTimer};
-use clack_host::events::io::{EventBuffer, InputEvents, OutputEvents};
-use clack_host::extensions::HostExtensions;
-use clack_host::host::{Host, HostAudioProcessor, HostMainThread, HostShared};
-use clack_host::plugin::{PluginAudioProcessorHandle, PluginMainThreadHandle, PluginSharedHandle};
+use clack_host::prelude::*;
 use dropseed_plugin_api::HostRequestChannelSender;
 use dropseed_plugin_api::{HostRequestFlags, PluginInstanceID};
 
 pub struct ClapHost;
 
 impl<'a> Host<'a> for ClapHost {
-    type AudioProcessor = ClapHostAudioProcessor<'a>;
     type Shared = ClapHostShared<'a>;
     type MainThread = ClapHostMainThread<'a>;
+    type AudioProcessor = ClapHostAudioProcessor<'a>;
 
     fn declare_extensions(builder: &mut HostExtensions<Self>, _shared: &Self::Shared) {
         builder
-            .register::<Log>()
+            .register::<HostLog>()
             .register::<ThreadCheck>()
             .register::<HostAudioPorts>()
             .register::<HostParams>()

--- a/src/plugin_host/external/clap/host/extensions.rs
+++ b/src/plugin_host/external/clap/host/extensions.rs
@@ -1,13 +1,13 @@
 use clack_extensions::audio_ports::{HostAudioPortsImplementation, RescanType};
 use clack_extensions::gui::{GuiError, GuiSize, HostGuiImplementation};
 use clack_extensions::latency::HostLatencyImpl;
-use clack_extensions::log::implementation::HostLog;
+use clack_extensions::log::HostLogImpl;
 use clack_extensions::log::LogSeverity;
 use clack_extensions::note_ports::{
     HostNotePortsImplementation, NoteDialects, NotePortRescanFlags,
 };
 use clack_extensions::params::{
-    HostParamsImplementation, HostParamsImplementationMainThread, ParamClearFlags, ParamRescanFlags,
+    HostParamsImplMainThread, HostParamsImplShared, ParamClearFlags, ParamRescanFlags,
 };
 use clack_extensions::thread_check::host::ThreadCheckImplementation;
 use clack_extensions::timer::{HostTimerImpl, TimerError, TimerId};
@@ -15,7 +15,7 @@ use dropseed_plugin_api::HostRequestFlags;
 
 use super::{ClapHostMainThread, ClapHostShared};
 
-impl<'a> HostLog for ClapHostShared<'a> {
+impl<'a> HostLogImpl for ClapHostShared<'a> {
     fn log(&self, severity: LogSeverity, message: &str) {
         // TODO: Make sure that the log and print methods don't allocate on the current thread.
         // If they do, then we need to come up with a realtime-safe way to print to the terminal.
@@ -97,14 +97,14 @@ impl<'a> HostNotePortsImplementation for ClapHostMainThread<'a> {
     }
 }
 
-impl<'a> HostParamsImplementation for ClapHostShared<'a> {
+impl<'a> HostParamsImplShared for ClapHostShared<'a> {
     #[inline]
     fn request_flush(&self) {
         self.host_request.request(HostRequestFlags::FLUSH_PARAMS);
     }
 }
 
-impl<'a> HostParamsImplementationMainThread for ClapHostMainThread<'a> {
+impl<'a> HostParamsImplMainThread for ClapHostMainThread<'a> {
     fn rescan(&mut self, flags: ParamRescanFlags) {
         if !self.shared.thread_ids.is_main_thread() {
             log::warn!("Plugin called clap_host_params->rescan() not in the main thread");

--- a/src/plugin_host/external/clap/process.rs
+++ b/src/plugin_host/external/clap/process.rs
@@ -1,42 +1,65 @@
 use atomic_refcell::AtomicRefMut;
 use clack_host::instance::processor::audio::{
-    AudioBuffers, AudioPortBuffer as ClapAudioPortBuffer, AudioPortBufferType, AudioPorts,
-    ChannelBuffer,
+    AudioPortBuffer as ClapAudioPortBuffer, AudioPortBufferType, AudioPorts, InputAudioBuffers,
+    InputChannel, OutputAudioBuffers,
 };
-use std::ops::{Deref, DerefMut};
+use smallvec::SmallVec;
 
 use dropseed_plugin_api::buffer::{BufferInner, RawAudioChannelBuffers};
 use dropseed_plugin_api::ProcBuffers;
 
 use super::plugin::AudioPortChannels;
 
-// Deref coercion struggles to go from AtomicRefMut<Vec<T>> to [T]
-struct BorrowedBuffer<'a, T: Copy + Clone + Send + Sync + 'static>(
-    AtomicRefMut<'a, BufferInner<T>>,
-);
+pub(crate) struct ClapAudioPorts {
+    pub(crate) input_buffer_slots: AudioPorts,
+    pub(crate) output_buffer_slots: AudioPorts,
+}
 
-impl<'a, T: Copy + Clone + Send + Sync + 'static> Deref for BorrowedBuffer<'a, T> {
-    type Target = [T];
+type BorrowedChannelsRefsMut<'a, T> = SmallVec<[AtomicRefMut<'a, BufferInner<T>>; 4]>;
 
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.0.data.as_ref()
+enum BorrowedPortMut<'a> {
+    F32(BorrowedChannelsRefsMut<'a, f32>),
+    F64(BorrowedChannelsRefsMut<'a, f64>),
+}
+
+impl<'a> BorrowedPortMut<'a> {
+    fn borrow(buf: &'a RawAudioChannelBuffers) -> Self {
+        match buf {
+            RawAudioChannelBuffers::F32(channels) => {
+                Self::F32(channels.iter().map(|c| c.borrow_mut()).collect())
+            }
+            RawAudioChannelBuffers::F64(channels) => {
+                Self::F64(channels.iter().map(|c| c.borrow_mut()).collect())
+            }
+        }
     }
 }
 
-impl<'a, T: Copy + Clone + Send + Sync + 'static> DerefMut for BorrowedBuffer<'a, T> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.data.as_mut_slice()
+type BorrowedPortsRefsMut<'a> = SmallVec<[(BorrowedPortMut<'a>, u32); 8]>;
+
+pub(crate) struct BorrowedClapAudioBuffers<'a> {
+    inputs: BorrowedPortsRefsMut<'a>,
+    outputs: BorrowedPortsRefsMut<'a>,
+}
+
+impl<'a> BorrowedClapAudioBuffers<'a> {
+    pub fn borrow_all(buffers: &'a ProcBuffers) -> Self {
+        Self {
+            inputs: buffers
+                .audio_in
+                .iter()
+                .map(|p| (BorrowedPortMut::borrow(&p._raw_channels), p.latency()))
+                .collect(),
+            outputs: buffers
+                .audio_out
+                .iter()
+                .map(|p| (BorrowedPortMut::borrow(&p._raw_channels), p.latency()))
+                .collect(),
+        }
     }
 }
 
-pub(crate) struct ClapProcess {
-    input_buffer_slots: AudioPorts,
-    output_buffer_slots: AudioPorts,
-}
-
-impl ClapProcess {
+impl ClapAudioPorts {
     pub(super) fn new(audio_port_channels: &AudioPortChannels) -> Self {
         // Allocate enough slots for each buffer so we can update them in
         // the audio thread.
@@ -52,57 +75,63 @@ impl ClapProcess {
         }
     }
 
-    pub fn update_buffers<'a>(
-        &'a mut self,
-        buffers: &'a ProcBuffers,
-    ) -> (AudioBuffers<'a>, AudioBuffers<'a>) {
-        debug_assert_eq!(buffers.audio_in.len(), self.input_buffer_slots.port_capacity());
-        debug_assert_eq!(buffers.audio_out.len(), self.output_buffer_slots.port_capacity());
+    pub fn create_inout_buffers<'s, 'b: 's>(
+        &'s mut self,
+        buffers: &'s mut BorrowedClapAudioBuffers<'b>,
+    ) -> (InputAudioBuffers<'s>, OutputAudioBuffers<'s>) {
+        debug_assert_eq!(buffers.inputs.len(), self.input_buffer_slots.port_capacity());
+        debug_assert_eq!(buffers.outputs.len(), self.output_buffer_slots.port_capacity());
 
-        let inputs = buffers.audio_in.iter().map(|port| ClapAudioPortBuffer {
-            latency: port.latency(),
-            channels: match &port._raw_channels {
-                RawAudioChannelBuffers::F32(channels) => {
-                    AudioPortBufferType::F32(channels.iter().map(|channel| {
-                        let buf = channel.borrow_mut();
-                        let is_constant = buf.is_constant;
-
-                        ChannelBuffer { data: BorrowedBuffer(buf), is_constant }
+        let inputs = buffers.inputs.iter_mut().map(|port| ClapAudioPortBuffer {
+            latency: port.1,
+            channels: match &mut port.0 {
+                BorrowedPortMut::F32(channels) => {
+                    AudioPortBufferType::F32(channels.iter_mut().map(|channel| {
+                        let is_constant = channel.is_constant;
+                        InputChannel::from_buffer(&mut channel.data, is_constant)
                     }))
                 }
-                RawAudioChannelBuffers::F64(channels) => {
-                    AudioPortBufferType::F64(channels.iter().map(|channel| {
-                        let buf = channel.borrow_mut();
-                        let is_constant = buf.is_constant;
-
-                        ChannelBuffer { data: BorrowedBuffer(buf), is_constant }
+                BorrowedPortMut::F64(channels) => {
+                    AudioPortBufferType::F64(channels.iter_mut().map(|channel| {
+                        let is_constant = channel.is_constant;
+                        InputChannel::from_buffer(&mut channel.data, is_constant)
                     }))
                 }
             },
         });
 
-        let outputs = buffers.audio_out.iter().map(|port| ClapAudioPortBuffer {
-            latency: port.latency(),
-            channels: match &port._raw_channels {
-                RawAudioChannelBuffers::F32(channels) => {
-                    AudioPortBufferType::F32(channels.iter().map(|channel| {
-                        let buf = channel.borrow_mut();
-                        let is_constant = buf.is_constant;
-
-                        ChannelBuffer { data: BorrowedBuffer(buf), is_constant }
-                    }))
-                }
-                RawAudioChannelBuffers::F64(channels) => {
-                    AudioPortBufferType::F64(channels.iter().map(|channel| {
-                        let buf = channel.borrow_mut();
-                        let is_constant = buf.is_constant;
-
-                        ChannelBuffer { data: BorrowedBuffer(buf), is_constant }
-                    }))
-                }
+        let outputs = buffers.outputs.iter_mut().map(|port| ClapAudioPortBuffer {
+            latency: port.1,
+            channels: match &mut port.0 {
+                BorrowedPortMut::F32(channels) => AudioPortBufferType::F32(
+                    channels.iter_mut().map(|channel| channel.data.as_mut_slice()),
+                ),
+                BorrowedPortMut::F64(channels) => AudioPortBufferType::F64(
+                    channels.iter_mut().map(|channel| channel.data.as_mut_slice()),
+                ),
             },
         });
 
-        (self.input_buffer_slots.with_data(inputs), self.output_buffer_slots.with_data(outputs))
+        (
+            self.input_buffer_slots.with_input_buffers(inputs),
+            self.output_buffer_slots.with_output_buffers(outputs),
+        )
+    }
+
+    pub fn update_output_constant_flags(&mut self, buffers: &mut BorrowedClapAudioBuffers) {
+        for (info, port) in self.output_buffer_slots.port_infos().zip(buffers.outputs.iter_mut()) {
+            match &mut port.0 {
+                BorrowedPortMut::F32(b) => {
+                    for (channel, is_constant) in b.iter_mut().zip(info.channel_constants()) {
+                        channel.is_constant = is_constant
+                    }
+                }
+                BorrowedPortMut::F64(b) => {
+                    for (channel, is_constant) in b.iter_mut().zip(info.channel_constants()) {
+                        channel.is_constant = is_constant
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR implements reading the constant flags from CLAP output ports data after processing.

This required an update of Clack, which had some minor module and types reorganization work done lately, which are also reflected in this PR. :slightly_smiling_face: 